### PR TITLE
Fix default promtail manifest

### DIFF
--- a/manifests/loki.yml
+++ b/manifests/loki.yml
@@ -36,18 +36,20 @@ instance_groups:
           promtail: { as: promtail, shared: true }
         properties:
           promtail:
-            tls: false
+            http:
+              tls: false
             server:
               http_listen_address: localhost
               http_listen_port: 9090
-            external_labels:
-              - syslog: "input"
+            loki:
+              external_labels:
+                syslog: "input"
             syslog:
               listen_address: 0.0.0.0
               listen_port: 601
               idle_timeout: 300
               labels:
-                - app: "syslog_test"
+                app: "syslog_test"
     networks:
       - name: cf
     stemcell: default


### PR DESCRIPTION
YAML structure is now as defined in spec, see
https://github.com/cloudfoundry-community/loki-boshrelease/blob/cfa473b8312077a963efd6f96a9672830beec0e6/jobs/promtail/spec

Without this I ran into an issue during "Rendering templates":

```
Task 387905 | 11:36:41 | Preparing deployment: Rendering templates (00:00:01)
                       L Error: Unable to render instance groups for deployment. Errors are:
  - Unable to render jobs for instance group 'loki'. Errors are:
    - Unable to render templates for job 'promtail'. Errors are:
      - Error filling in template 'config/config.yml.erb' (line 56: undefined method `each_pair' for an instance of Array)
 ```
 
Also `line 56: Can't find property '["promtail.loki.external_labels"]'.`